### PR TITLE
Mono embedded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,16 @@ set(REQUIRED_LIBS_QUALIFIED Qt6::Core Qt6::Gui Qt6::Widgets)
 
 # Includes
 include(FindPackageHandleStandardArgs)
-include_directories(include /usr/include/mono-2.0) # new api
 
-# Find python
+# Find reqs
 find_package(Python3 3.6 EXACT COMPONENTS Interpreter Development)
 message("Python3.6 library files: ${Python3_LIBRARIES}")
+find_library(MONO NAMES mono-2.0)
+message("Mono found: ${MONO}")
+find_library(LIBMONO NAMES mono-native libmono-native)
+message("LIBMONONATIVE found: ${LIBMONO}")
+find_library(LIBMONOSGEN NAMES monosgen monosgen-2.0 libmonosgen libmonosgen-2.0)
+message("LIBMONOSGEN found: ${LIBMONOSGEN}")
 
 
 if (NOT CMAKE_PREFIX_PATH)
@@ -27,15 +32,14 @@ if (NOT CMAKE_PREFIX_PATH)
 endif ()
 # Config
 execute_process(COMMAND ${CMAKE_SOURCE_DIR}/configure ${CMAKE_SOURCE_DIR} ${Python3_LIBRARIES})
-execute_process(COMMAND rm -r ${CMAKE_BINARY_DIR}/Lean -f)
 message("Moving assets")
 execute_process(COMMAND cp -r ${CMAKE_SOURCE_DIR}/src/assets ${CMAKE_BINARY_DIR}/assets)
 
 
 # Building
-add_executable(${PROJECT_NAME} src/main.cpp src/QJsonModel.cpp src/QJsonModel.h src/TreeEditor.h src/TreeEditor.cpp src/MainWindow.cpp src/MainWindow.h)
+add_executable(${PROJECT_NAME} src/main.cpp src/QJsonModel.cpp src/QJsonModel.h src/TreeEditor.h src/TreeEditor.cpp src/MainWindow.cpp src/MainWindow.h src/MonoContainer.cpp src/MonoContainer.h)
 find_package(Qt${QT_VERSION} COMPONENTS ${REQUIRED_LIBS} REQUIRED)
-target_link_libraries(${PROJECT_NAME} ${REQUIRED_LIBS_QUALIFIED} stdc++fs)
+target_link_libraries(${PROJECT_NAME} ${REQUIRED_LIBS_QUALIFIED} stdc++fs ${MONO} ${LIBMONO} ${LIBMONOSGEN})
 
 add_custom_target(copy_asset_files ALL
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ find_library(LIBMONO NAMES mono-native libmono-native)
 message("LIBMONONATIVE found: ${LIBMONO}")
 find_library(LIBMONOSGEN NAMES monosgen monosgen-2.0 libmonosgen libmonosgen-2.0)
 message("LIBMONOSGEN found: ${LIBMONOSGEN}")
+find_library(LIBTBB NAMES libtbb tbb)
+message("LIBTBB found: ${LIBTBB}")
 
 
 if (NOT CMAKE_PREFIX_PATH)
@@ -39,7 +41,7 @@ execute_process(COMMAND cp -r ${CMAKE_SOURCE_DIR}/src/assets ${CMAKE_BINARY_DIR}
 # Building
 add_executable(${PROJECT_NAME} src/main.cpp src/QJsonModel.cpp src/QJsonModel.h src/TreeEditor.h src/TreeEditor.cpp src/MainWindow.cpp src/MainWindow.h src/MonoContainer.cpp src/MonoContainer.h)
 find_package(Qt${QT_VERSION} COMPONENTS ${REQUIRED_LIBS} REQUIRED)
-target_link_libraries(${PROJECT_NAME} ${REQUIRED_LIBS_QUALIFIED} stdc++fs ${MONO} ${LIBMONO} ${LIBMONOSGEN})
+target_link_libraries(${PROJECT_NAME} ${REQUIRED_LIBS_QUALIFIED} stdc++fs ${MONO} ${LIBMONO} ${LIBMONOSGEN} ${LIBTBB})
 
 add_custom_target(copy_asset_files ALL
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/scripts/lean_builder.sh
+++ b/scripts/lean_builder.sh
@@ -18,8 +18,8 @@
 (mkdir lean_bin && mkdir lean_bin/Data) || echo "lean_bin directory exists -- overwriting files..."
 cd Lean || eval "git clone http://github.com/QuantConnect/Lean && cd Lean"
 nuget restore || dotnet restore || exit 1
-msbuild -p:Configuration=Release || dotnet msbuild -p:Configuration=Release || exit 1
-cp -r Launcher/bin/Release/* ../lean_bin
+msbuild -p:Configuration=Debug || dotnet msbuild -p:Configuration=Debug || exit 1
+cp -r Launcher/bin/Debug/* ../lean_bin
 cp -r Data/* ../lean_bin/Data
 
 if [ "$1" != -ne ]; then

--- a/scripts/lean_builder.sh
+++ b/scripts/lean_builder.sh
@@ -14,30 +14,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-(mkdir lean_bin && mkdir lean_bin/Data) || echo "lean_bin directory exists -- overwriting files..."
+echo "Lean Configuration"
+echo "=================="
 cd Lean || eval "git clone http://github.com/QuantConnect/Lean && cd Lean"
-nuget restore || dotnet restore || exit 1
-msbuild -p:Configuration=Debug || dotnet msbuild -p:Configuration=Debug || exit 1
-cp -r Launcher/bin/Debug/* ../lean_bin
-cp -r Data/* ../lean_bin/Data
+echo "Lean installed."
 
-if [ "$1" != -ne ]; then
-  echo "Building with examples"
-  mkdir ../Algorithm.CSharp || exit
-  mkdir ../Algorithm.Python || exit
-  cp -r Algorithm.CSharp/* ../Algorithm.CSharp
-  cp -r Algorithm.Python/* ../Algorithm.Python
-fi
-
-cd .. && rm -r Lean -f
-echo "Successfully created Lean binaries"
-
-# == Testing with examples == (requires user input)
-#if [ "$1" != -ne ]; then
-#  cd ../lean_bin || exit 1
-#  echo "Testing..."
-#  echo "----------"
-#  mono ./QuantConnect.Lean.Launcher.exe --
-#fi
 exit 0

--- a/scripts/py_config.sh
+++ b/scripts/py_config.sh
@@ -14,7 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+echo "Configuring Python"
+echo "=================="
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   MAP_CONF="<dllmap os=\"linux\" dll=\"python3.6m\" target=\"$1\"/>"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
@@ -23,13 +24,20 @@ else
   exit 0
 fi
 echo "Writing Python configuration to Python.Runtime.dll.config"
-
-rm lean_bin/Python.Runtime.dll.config || echo "Nothing to remove"
-
-cat <<EOF >>lean_bin/Python.Runtime.dll.config
+rm Lean/Common/Python/Python.Runtime.dll.config
+cat <<EOF >>Lean/Common/Python/Python.Runtime.dll.config
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     $MAP_CONF
 </configuration>
 EOF
+
+echo "Building Lean.Launcher"
+echo "======================"
+
+cd Lean || exit 1
+nuget restore || dotnet restore || exit 1
+msbuild -p:Configuration=Debug || dotnet msbuild -p:Configuration=Debug || exit 1
+echo "Successfully configured Lean and Python."
+echo "========================================"
 exit 0

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -79,8 +79,8 @@ void MainWindow::runAlgorithm() {
     destination << source.rdbuf();
     std::cout << "\nSuccessfully copied config.";
     auto mono = MonoContainer("Lean_Mono", "lean_bin/QuantConnect.Lean.Launcher.exe");
-    auto ret = mono.Invoke("QuantConnect.Lean.Launcher", "Program", "Main");
-    printf("%", ret);;
+    void *ret = mono.Exec();
+    printf("%", &ret);
 }
 
 void MainWindow::configure() { editor->show(); }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -75,10 +75,10 @@ MainWindow::MainWindow() {
 void MainWindow::runAlgorithm() {
     // Move config
     std::ifstream source("assets/config/config.json", std::ios::binary);
-    std::ofstream destination("lean_bin/config.json", std::ios::binary);
+    std::ofstream destination("Lean/Launcher/bin/Debug/config.json", std::ios::binary);
     destination << source.rdbuf();
-    std::cout << "\nSuccessfully copied config.";
-    auto mono = MonoContainer("Lean_Mono", "lean_bin/QuantConnect.Lean.Launcher.exe");
+    std::cout << "\nSuccessfully copied config.\n";
+    auto mono = MonoContainer("QuantConnect.Lean.Launcher", "Lean/Launcher/bin/Debug/QuantConnect.Lean.Launcher.exe");
     void *ret = mono.Exec();
     printf("%", &ret);
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -19,6 +19,7 @@
 
 #include "MainWindow.h"
 #include "TreeEditor.h"
+#include "MonoContainer.h"
 #include <QDialogButtonBox>
 #include <QSessionManager>
 #include <QtWidgets>
@@ -69,11 +70,7 @@ MainWindow::MainWindow() {
 }
 
 
-#define MONOSHELL "\
-#/bin/bash \n\
-xterm -e \" cd $PWD/lean_bin\;mono ./QuantConnect.Lean.Launcher.exe \" \n\
-clear\
-"
+
 
 void MainWindow::runAlgorithm() {
     // Move config
@@ -81,7 +78,9 @@ void MainWindow::runAlgorithm() {
     std::ofstream destination("lean_bin/config.json", std::ios::binary);
     destination << source.rdbuf();
     std::cout << "\nSuccessfully copied config.";
-    system(MONOSHELL);
+    auto mono = MonoContainer("Lean_Mono", "lean_bin/QuantConnect.Lean.Launcher.exe");
+    auto ret = mono.Invoke("QuantConnect.Lean.Launcher", "Program", "Main");
+    printf("%", ret);;
 }
 
 void MainWindow::configure() { editor->show(); }

--- a/src/MonoContainer.cpp
+++ b/src/MonoContainer.cpp
@@ -17,6 +17,7 @@
 #include <mono/jit/jit.h>
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/mono-config.h>
+#include <execution>
 #include "MonoContainer.h"
 
 MonoContainer::MonoContainer(char *domain, char *assembly) {
@@ -26,8 +27,10 @@ MonoContainer::MonoContainer(char *domain, char *assembly) {
 }
 
 void *MonoContainer::Exec() {
-    char **argv = reinterpret_cast<char **>(mono_assembly_get_name(monoAssembly));
+    chdir("Lean/Launcher/bin/Debug");
+    char **argv = (char **) mono_assembly_get_name(monoAssembly);
     mono_jit_exec(monoDomain, monoAssembly, 1, argv);
+    chdir("../../../..");
 }
 
 MonoContainer::~MonoContainer() {

--- a/src/MonoContainer.cpp
+++ b/src/MonoContainer.cpp
@@ -20,16 +20,14 @@
 #include "MonoContainer.h"
 
 MonoContainer::MonoContainer(char *domain, char *assembly) {
-    mono_config_parse("/etc/mono/config");
+    mono_config_parse(NULL);
     monoDomain = mono_jit_init(domain);
     monoAssembly = mono_domain_assembly_open(monoDomain, assembly);
 }
 
-MonoObject *MonoContainer::Invoke(char *monoNamespace, char *className, char *method) {
-    auto monoClass = mono_class_from_name(mono_assembly_get_image(monoAssembly), monoNamespace, className);
-    auto monoMethod = mono_class_get_method_from_name(monoClass, method, 1);
-    void *args[1];
-    return mono_runtime_invoke(monoMethod, nullptr, args, nullptr);
+void *MonoContainer::Exec() {
+    char **argv = reinterpret_cast<char **>(mono_assembly_get_name(monoAssembly));
+    mono_jit_exec(monoDomain, monoAssembly, 1, argv);
 }
 
 MonoContainer::~MonoContainer() {

--- a/src/MonoContainer.cpp
+++ b/src/MonoContainer.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Aaron Janeiro Stone
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#include <mono/jit/jit.h>
+#include <mono/metadata/assembly.h>
+#include <mono/metadata/mono-config.h>
+#include "MonoContainer.h"
+
+MonoContainer::MonoContainer(char *domain, char *assembly) {
+    mono_config_parse("/etc/mono/config");
+    monoDomain = mono_jit_init(domain);
+    monoAssembly = mono_domain_assembly_open(monoDomain, assembly);
+}
+
+MonoObject *MonoContainer::Invoke(char *monoNamespace, char *className, char *method) {
+    auto monoClass = mono_class_from_name(mono_assembly_get_image(monoAssembly), monoNamespace, className);
+    auto monoMethod = mono_class_get_method_from_name(monoClass, method, 1);
+    void *args[1];
+    return mono_runtime_invoke(monoMethod, nullptr, args, nullptr);
+}
+
+MonoContainer::~MonoContainer() {
+    mono_jit_cleanup(monoDomain);
+    mono_assembly_close(monoAssembly);
+}
+

--- a/src/MonoContainer.h
+++ b/src/MonoContainer.h
@@ -16,7 +16,6 @@
 
 #ifndef QTLEAN_MONOCONTAINER_H
 #define QTLEAN_MONOCONTAINER_H
-
 #include <mono/jit/jit.h>
 #include <mono/metadata/assembly.h>
 
@@ -25,7 +24,7 @@ class MonoContainer {
 public:
     MonoContainer(char *domain, char *assembly);
 
-    MonoObject *Invoke(char *monoNamespace, char *className, char *method);
+    void * Exec();
 
     ~MonoContainer();
 

--- a/src/MonoContainer.h
+++ b/src/MonoContainer.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Aaron Janeiro Stone
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#ifndef QTLEAN_MONOCONTAINER_H
+#define QTLEAN_MONOCONTAINER_H
+
+#include <mono/jit/jit.h>
+#include <mono/metadata/assembly.h>
+
+
+class MonoContainer {
+public:
+    MonoContainer(char *domain, char *assembly);
+
+    MonoObject *Invoke(char *monoNamespace, char *className, char *method);
+
+    ~MonoContainer();
+
+private:
+    MonoDomain *monoDomain;
+    MonoAssembly *monoAssembly;
+};
+
+
+#endif //QTLEAN_MONOCONTAINER_H

--- a/src/assets/config/config.json
+++ b/src/assets/config/config.json
@@ -18,7 +18,7 @@
   "coinapi-product": "free",
   "data-aggregator": "QuantConnect.Lean.Engine.DataFeeds.AggregationManager",
   "data-channel-provider": "DataChannelProvider",
-  "data-folder": "Data/",
+  "data-folder": "../../../Data/",
   "data-provider": "QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider",
   "debugging": "false",
   "debugging-method": "LocalCmdline",

--- a/src/assets/config/default_config.json
+++ b/src/assets/config/default_config.json
@@ -18,7 +18,7 @@
   "coinapi-product": "free",
   "data-aggregator": "QuantConnect.Lean.Engine.DataFeeds.AggregationManager",
   "data-channel-provider": "DataChannelProvider",
-  "data-folder": "Data/",
+  "data-folder": "../../../Data/",
   "data-provider": "QuantConnect.Lean.Engine.DataFeeds.DefaultDataProvider",
   "debugging": "false",
   "debugging-method": "LocalCmdline",


### PR DESCRIPTION
Via embedding, QtLean directly interacts with Lean (i.e., without bash needed for interfacing -- useful as C# objects are now accessible without requiring any modification of the base Lean repo).